### PR TITLE
Add buff card support

### DIFF
--- a/src/game.test.ts
+++ b/src/game.test.ts
@@ -3,6 +3,7 @@ import { Player } from "./player";
 import { Game } from "./game";
 import { IInterfaceUsuario } from "./IInterfaceUsuario";
 import { CardCura } from "./cards/cardCura";
+import { CardBuff } from "./cards/cardBuff";
 import { ICard } from "./cards/ICard";
 
 describe("Game", () => {
@@ -210,5 +211,21 @@ describe("Game", () => {
 
     expect(ataqueSpy).toBeCalledTimes(0);
     expect(curarSpy).toBeCalledTimes(1);
+  });
+
+  it("Deve chamar funcao buffar do jogador caso ele tenha escolhido uma carta do tipo buff", () => {
+    selecionarCarta
+      .mockReturnValueOnce(new CardBuff(2))
+      .mockReturnValueOnce(undefined);
+
+    const atacarSpy = jest.spyOn(_sut.jogador1, "atacar");
+    const curarSpy = jest.spyOn(_sut.jogador1, "curar");
+    const buffarSpy = jest.spyOn(_sut.jogador1, "buffar");
+
+    _sut.rodarTurno(_sut.jogador1, _sut.jogador2);
+
+    expect(atacarSpy).toBeCalledTimes(0);
+    expect(curarSpy).toBeCalledTimes(0);
+    expect(buffarSpy).toBeCalledTimes(1);
   });
 });

--- a/src/game.ts
+++ b/src/game.ts
@@ -60,6 +60,9 @@ export class Game {
       if (carta.obterTipo() === enumTipo.cura) {
         jogadorAtacante.curar(carta);
       }
+      if (carta.obterTipo() === enumTipo.buff) {
+        jogadorAtacante.buffar(carta);
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- support buff cards during turns
- test buff card usage

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68487433f3c08328955009b060e39801