### PR TITLE
Add restoreAllMocks to game tests

### DIFF
--- a/src/game.test.ts
+++ b/src/game.test.ts
@@ -42,6 +42,7 @@ describe("Game", () => {
   afterEach(() => {
     j1EC.mockClear();
     j2EC.mockClear();
+    jest.restoreAllMocks();
   });
 
   it("Deve haver dois jogadores em uma partida", () => {


### PR DESCRIPTION
## Summary
- reset all mocks after each `Game` test to ensure spies are restored

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68487437435883288e77c0a1d6ffe873