### PR TITLE
Adjust shield to absorb partial damage

### DIFF
--- a/src/cards/cardEscudo.test.ts
+++ b/src/cards/cardEscudo.test.ts
@@ -1,0 +1,22 @@
+import { CardEscudo } from "./cardEscudo";
+import { enumTipo } from "../tipo.enum";
+
+describe("CardEscudo", () => {
+  let _sut: CardEscudo;
+
+  beforeEach(() => {
+    _sut = new CardEscudo(2);
+  });
+
+  it("Deve retornar o custo da carta quando a funcao obterCusto for chamada", () => {
+    expect(_sut.obterCusto()).toBe(2);
+  });
+
+  it("Deve retornar o valor da carta quando a funcao obterValor for chamada", () => {
+    expect(_sut.obterValor()).toBe(2);
+  });
+
+  it("Deve retornar o tipo escudo quando a funcao obterTipo for chamada", () => {
+    expect(_sut.obterTipo()).toBe(enumTipo.escudo);
+  });
+});

--- a/src/cards/cardEscudo.ts
+++ b/src/cards/cardEscudo.ts
@@ -1,0 +1,25 @@
+import { enumTipo } from "../tipo.enum";
+import { AbstractCard } from "./abstractCard";
+
+export class CardEscudo extends AbstractCard {
+  private custo: number;
+  private valor: number;
+
+  constructor(valor: number) {
+    super();
+    this.custo = valor;
+    this.valor = valor;
+  }
+
+  obterCusto(): number {
+    return this.custo;
+  }
+
+  obterValor(): number {
+    return this.valor;
+  }
+
+  obterTipo(): enumTipo {
+    return enumTipo.escudo;
+  }
+}

--- a/src/game.test.ts
+++ b/src/game.test.ts
@@ -13,6 +13,7 @@ describe("Game", () => {
   let j1CC: jest.SpyInstance;
   let j2CC: jest.SpyInstance;
   let j1Atacar: jest.SpyInstance;
+  let j1Buffar: jest.SpyInstance;
   let selecionarCarta: jest.Mock<ICard | undefined>;
   let interfaceUsuario: IInterfaceUsuario;
 
@@ -36,6 +37,10 @@ describe("Game", () => {
       _sut.jogador1.mao.splice(_sut.jogador1.mao.findIndex(y => y.toEquals(x)), 1);
       return x.obterValor();
     });
+    j1Buffar = jest.spyOn(p1, "buffar").mockImplementation((x) => {
+      _sut.jogador1.mana -= x.obterCusto();
+      _sut.jogador1.mao.splice(_sut.jogador1.mao.findIndex(y => y.toEquals(x)), 1);
+    });
 
     _sut = new Game(p1, p2, interfaceUsuario);
   });
@@ -43,6 +48,7 @@ describe("Game", () => {
   afterEach(() => {
     j1EC.mockClear();
     j2EC.mockClear();
+    if (j1Buffar) j1Buffar.mockClear();
     jest.restoreAllMocks();
   });
 

--- a/src/game.ts
+++ b/src/game.ts
@@ -63,6 +63,9 @@ export class Game {
       if (carta.obterTipo() === enumTipo.buff) {
         jogadorAtacante.buffar(carta);
       }
+      if (carta.obterTipo() === enumTipo.escudo) {
+        jogadorAtacante.proteger(carta);
+      }
 
     }
   }

--- a/src/player.test.ts
+++ b/src/player.test.ts
@@ -2,6 +2,7 @@ import { Player } from "./player";
 import { CardAtaque } from "./cards/cardAtaque";
 import { CardCura } from "./cards/cardCura";
 import { CardBuff } from "./cards/cardBuff";
+import { CardEscudo } from "./cards/cardEscudo";
 import { enumTipo } from "./tipo.enum";
 
 describe("player", () => {
@@ -336,6 +337,33 @@ describe("player", () => {
     _sut.buffar(new CardBuff(2));
     _sut.curar(new CardCura(4));
     expect(_sut.obterBuff()).toBe(0);
+  });
+
+  it("Deve ativar escudo e reduzir o dano do proximo ataque", () => {
+    _sut.mao = [new CardEscudo(2)];
+    _sut.mana = 2;
+    _sut.proteger(new CardEscudo(2));
+    _sut.vida = 10;
+    _sut.defenderAtaque(10);
+    expect(_sut.vida).toBe(2);
+  });
+
+  it("Deve consumir o escudo apos reduzir o dano", () => {
+    _sut.mao = [new CardEscudo(2)];
+    _sut.mana = 2;
+    _sut.proteger(new CardEscudo(2));
+    _sut.vida = 10;
+    _sut.defenderAtaque(1);
+    _sut.defenderAtaque(3);
+    expect(_sut.vida).toBe(7);
+  });
+
+  it("Deve remover a carta escudo da mao e gastar mana ao usar", () => {
+    _sut.mao = [new CardEscudo(2), new CardAtaque(1)];
+    _sut.mana = 3;
+    _sut.proteger(new CardEscudo(2));
+    expect(_sut.mao.length).toBe(1);
+    expect(_sut.mana).toBe(1);
   });
 
 

--- a/src/player.ts
+++ b/src/player.ts
@@ -9,6 +9,7 @@ export class Player {
   deck: ICard[];
   mao: ICard[];
   buff: number;
+  escudoValor: number;
 
   constructor(nome: string) {
     this.nome = nome;
@@ -39,6 +40,7 @@ export class Player {
     ];
     this.mao = [];
     this.buff = 0;
+    this.escudoValor = 0;
   }
   private validarUtilizacao(carta: ICard, tipo: enumTipo) {
     if (!this.mao.some((x) => x.toEquals(carta))) {
@@ -89,6 +91,16 @@ export class Player {
     );
   }
 
+  proteger(carta: ICard) {
+    this.validarUtilizacao(carta, enumTipo.escudo);
+    this.escudoValor = carta.obterValor();
+    this.mana -= carta.obterCusto();
+    this.mao.splice(
+      this.mao.findIndex((cartaMao) => cartaMao.toEquals(carta)),
+      1
+    );
+  }
+
   obterBuff() {
     return this.buff;
   }
@@ -131,6 +143,14 @@ export class Player {
   }
 
   defenderAtaque(dano: number) {
+    if (this.escudoValor > 0) {
+      const danoReduzido = dano - this.escudoValor;
+      this.escudoValor = 0;
+      if (danoReduzido > 0) {
+        this.vida -= danoReduzido;
+      }
+      return;
+    }
     this.vida -= dano;
   }
 

--- a/src/tipo.enum.ts
+++ b/src/tipo.enum.ts
@@ -1,5 +1,6 @@
 export enum enumTipo {
-  ataque, 
+  ataque,
   cura,
-  buff
+  buff,
+  escudo
 }


### PR DESCRIPTION
## Summary
- track remaining shield value rather than a boolean
- have Player.proteger store shield value
- reduce incoming damage by shield value in Player.defenderAtaque
- update tests for new shield behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68487a249d848328a0ea923d177d5fe5