### PR TITLE
Implement incremental buff logic

### DIFF
--- a/src/cards/cardBuff.test.ts
+++ b/src/cards/cardBuff.test.ts
@@ -13,9 +13,9 @@ describe("CardBuff", () => {
   });
 
   it("Deve retornar o valor do modificador quando a funcao obterValor for chamada", () => {
-    expect(_sut.obterValor()).toBe(2.0);
+    expect(_sut.obterValor()).toBe(1.5);
     _sut = new CardBuff(3)
-    expect(_sut.obterValor()).toBe(1.6);
+    expect(_sut.obterValor()).toBe(1.3);
   });
 
   it("Deve retornar o tipo ataque quando a funcao obterTipo for chamada", () => {

--- a/src/cards/cardBuff.ts
+++ b/src/cards/cardBuff.ts
@@ -15,7 +15,7 @@ export class CardBuff extends AbstractCard {
   }
 
   obterValor(): number {
-    return 1 + 0.2 * this.custo;
+    return 1 + 0.1 * this.custo;
   }
 
   obterTipo(): enumTipo {

--- a/src/player.test.ts
+++ b/src/player.test.ts
@@ -248,7 +248,7 @@ describe("player", () => {
     _sut.vida = 6;
 
     _sut.buffar(new CardBuff(5));
-    expect(_sut.obterBuff()).toBe(2.0);
+    expect(_sut.obterBuff()).toBe(1.5);
   });
 
   it("Deve retornar valor stackado de buff quando chamar funcao obterBuff", () => {
@@ -258,7 +258,7 @@ describe("player", () => {
 
     _sut.buffar(new CardBuff(5));
     _sut.buffar(new CardBuff(2));
-    expect(_sut.obterBuff()).toBe(3.4);
+    expect(_sut.obterBuff()).toBeCloseTo(1.8);
   });
 
 
@@ -308,7 +308,7 @@ describe("player", () => {
 
     _sut.buffar(new CardBuff(2));
    
-    expect( _sut.atacar(new CardAtaque(4))).toBe(6);
+    expect( _sut.atacar(new CardAtaque(4))).toBe(5);
   });
 
   it("Deve remover buff se for utilisado", () => {
@@ -317,7 +317,18 @@ describe("player", () => {
 
     _sut.buffar(new CardBuff(2));
     _sut.atacar(new CardAtaque(4));
-    expect(_sut.obterBuff()).toBe(0);
+    expect(_sut.obterBuff()).toBe(1);
+  });
+
+  it("Deve aplicar buff no escudo", () => {
+    _sut.mao = [new CardBuff(2), new CardEscudo(2)];
+    _sut.mana = 4;
+
+    _sut.buffar(new CardBuff(2));
+    _sut.proteger(new CardEscudo(2));
+
+    expect(_sut.escudos[0]).toBeCloseTo(2.4);
+    expect(_sut.obterBuff()).toBe(1);
   });
 
   it("Deve aplicar buff na cura", () => {
@@ -326,7 +337,7 @@ describe("player", () => {
     _sut.vida= 10
     _sut.buffar(new CardBuff(2));
     _sut.curar(new CardCura(4))
-    expect(_sut.vida).toBe(16);
+    expect(_sut.vida).toBe(15);
   });
 
   it("Deve remover buff apos ser utilisado na cura", () => {
@@ -336,7 +347,7 @@ describe("player", () => {
 
     _sut.buffar(new CardBuff(2));
     _sut.curar(new CardCura(4));
-    expect(_sut.obterBuff()).toBe(0);
+    expect(_sut.obterBuff()).toBe(1);
   });
 
   it("Deve ativar escudo e reduzir o dano do proximo ataque", () => {

--- a/src/player.ts
+++ b/src/player.ts
@@ -39,7 +39,7 @@ export class Player {
       new CardAtaque(8),
     ];
     this.mao = [];
-    this.buff = 0;
+    this.buff = 1;
     this.escudos = [];
   }
   private validarUtilizacao(carta: ICard, tipo: enumTipo) {
@@ -62,9 +62,9 @@ export class Player {
           this.mao.findIndex((cardMao) => cardMao.toEquals(carta)),
           1
         )[0]
-        .obterValor() * (this.obterBuff() ? this.obterBuff() : 1);
+        .obterValor() * this.buff;
 
-    this.buff = 0;
+    this.buff = 1;
     return Math.round(dano);
   }
 
@@ -78,12 +78,12 @@ export class Player {
       )[0]
       .obterValor();
 
-    this.vida += Math.round(cura * (this.obterBuff() ? this.obterBuff() : 1));
-    this.buff = 0;
+    this.vida += Math.round(cura * this.buff);
+    this.buff = 1;
   }
   buffar(carta: ICard) {
     this.validarUtilizacao(carta, enumTipo.buff);
-    this.buff += carta.obterValor();
+    this.buff = this.buff * carta.obterValor();
     this.mana -= carta.obterCusto();
     this.mao.splice(
       this.mao.findIndex((cartaMao) => cartaMao.toEquals(carta)),
@@ -93,12 +93,13 @@ export class Player {
 
   proteger(carta: ICard) {
     this.validarUtilizacao(carta, enumTipo.escudo);
-    this.escudos.push(carta.obterValor());
+    this.escudos.push(carta.obterValor() * this.buff);
     this.mana -= carta.obterCusto();
     this.mao.splice(
       this.mao.findIndex((cartaMao) => cartaMao.toEquals(carta)),
       1
     );
+    this.buff = 1;
   }
 
   obterBuff() {


### PR DESCRIPTION
## Summary
- update buff card value calculation
- rework buff handling to apply only to the next card and allow stacking
- apply buffs to shields as well
- adapt unit tests for new buff behavior

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68488803b47883288df454904387b7c1