### PR TITLE
Add poison card mechanic

### DIFF
--- a/src/cards/cardVeneno.test.ts
+++ b/src/cards/cardVeneno.test.ts
@@ -1,0 +1,38 @@
+import { CardVeneno } from "./cardVeneno";
+import { enumTipo } from "../tipo.enum";
+import { CardAtaque } from "./cardAtaque";
+
+describe("CardVeneno", () => {
+  let _sut: CardVeneno;
+
+  beforeEach(() => {
+    _sut = new CardVeneno(3);
+  });
+
+  it("Deve retornar o custo da carta quando a funcao obterCusto for chamada", () => {
+    expect(_sut.obterCusto()).toBe(3);
+  });
+
+  it("Deve retornar o valor da carta quando a funcao obterValor for chamada", () => {
+    expect(_sut.obterValor()).toBe(3);
+  });
+
+  it("Deve retornar o tipo veneno quando a funcao obterTipo for chamada", () => {
+    expect(_sut.obterTipo()).toBe(enumTipo.veneno);
+  });
+
+  it("Deve retornar falso quando as cartas forem diferentes", () => {
+    const outro = new CardVeneno(2);
+    expect(_sut.toEquals(outro)).toBeFalsy();
+  });
+
+  it("Deve retornar verdadeiro quando as cartas forem iguais", () => {
+    const igual = new CardVeneno(3);
+    expect(_sut.toEquals(igual)).toBeTruthy();
+  });
+
+  it("Deve retornar falso quando o tipo for diferente", () => {
+    const diferenteTipo = new CardAtaque(3);
+    expect(_sut.toEquals(diferenteTipo)).toBeFalsy();
+  });
+});

--- a/src/cards/cardVeneno.ts
+++ b/src/cards/cardVeneno.ts
@@ -1,0 +1,25 @@
+import { enumTipo } from "../tipo.enum";
+import { AbstractCard } from "./abstractCard";
+
+export class CardVeneno extends AbstractCard {
+  private custo: number;
+  private valor: number;
+
+  constructor(valor: number) {
+    super();
+    this.custo = valor;
+    this.valor = valor;
+  }
+
+  obterCusto(): number {
+    return this.custo;
+  }
+
+  obterValor(): number {
+    return this.valor;
+  }
+
+  obterTipo(): enumTipo {
+    return enumTipo.veneno;
+  }
+}

--- a/src/game.ts
+++ b/src/game.ts
@@ -36,6 +36,7 @@ export class Game {
   }
 
   rodarTurno(jogadorAtacante: Player, jogadorDefensor: Player) {
+    jogadorAtacante.processarVenenos();
     jogadorAtacante.incrementarManaSlot();
     jogadorAtacante.reiniciarMana();
     jogadorAtacante.comprarCarta();
@@ -65,6 +66,10 @@ export class Game {
       }
       if (carta.obterTipo() === enumTipo.escudo) {
         jogadorAtacante.proteger(carta);
+      }
+      if (carta.obterTipo() === enumTipo.veneno) {
+        const duracao = jogadorAtacante.envenenar(carta);
+        jogadorDefensor.aplicarVeneno(duracao);
       }
 
     }

--- a/src/player.test.ts
+++ b/src/player.test.ts
@@ -3,6 +3,7 @@ import { CardAtaque } from "./cards/cardAtaque";
 import { CardCura } from "./cards/cardCura";
 import { CardBuff } from "./cards/cardBuff";
 import { CardEscudo } from "./cards/cardEscudo";
+import { CardVeneno } from "./cards/cardVeneno";
 import { enumTipo } from "./tipo.enum";
 
 describe("player", () => {
@@ -387,6 +388,37 @@ describe("player", () => {
     _sut.proteger(new CardEscudo(2));
     expect(_sut.mao.length).toBe(1);
     expect(_sut.mana).toBe(1);
+  });
+
+  it("Deve aplicar veneno ao oponente e reduzir a vida no inicio do turno", () => {
+    _sut.mao = [new CardVeneno(3)];
+    _sut.mana = 3;
+
+    const duracao = _sut.envenenar(new CardVeneno(3));
+    const oponente = new Player("op");
+    oponente.aplicarVeneno(duracao);
+    oponente.processarVenenos();
+    expect(oponente.vida).toBe(29);
+    oponente.processarVenenos();
+    expect(oponente.vida).toBe(28);
+    oponente.processarVenenos();
+    expect(oponente.vida).toBe(27);
+    oponente.processarVenenos();
+    expect(oponente.vida).toBe(27); // sem veneno
+  });
+
+  it("Deve stackar varias instancias de veneno", () => {
+    const op = new Player("op");
+    op.aplicarVeneno(2);
+    op.aplicarVeneno(3);
+    op.processarVenenos();
+    expect(op.vida).toBe(28);
+    op.processarVenenos();
+    expect(op.vida).toBe(26);
+    op.processarVenenos();
+    expect(op.vida).toBe(25);
+    op.processarVenenos();
+    expect(op.vida).toBe(25);
   });
 
 

--- a/src/player.ts
+++ b/src/player.ts
@@ -10,6 +10,7 @@ export class Player {
   mao: ICard[];
   buff: number;
   escudos: number[];
+  venenos: number[];
 
   constructor(nome: string) {
     this.nome = nome;
@@ -23,6 +24,7 @@ export class Player {
     this.mao = [];
     this.buff = 1;
     this.escudos = [];
+    this.venenos = [];
   }
 
   private consumirCarta(carta: ICard): ICard {
@@ -68,6 +70,30 @@ export class Player {
     const cartaUsada = this.consumirCarta(carta);
     this.escudos.push(cartaUsada.obterValor() * this.buff);
     this.buff = 1;
+  }
+
+  envenenar(carta: ICard) {
+    this.validarUtilizacao(carta, enumTipo.veneno);
+    const cartaUsada = this.consumirCarta(carta);
+    const duracao = Math.floor(cartaUsada.obterValor() * this.buff);
+    this.buff = 1;
+    return duracao;
+  }
+
+  aplicarVeneno(duracao: number) {
+    if (duracao > 0) {
+      this.venenos.push(duracao);
+    }
+  }
+
+  processarVenenos() {
+    if (this.venenos.length === 0) {
+      return;
+    }
+    this.vida -= this.venenos.length;
+    this.venenos = this.venenos
+      .map((v) => v - 1)
+      .filter((v) => v > 0);
   }
 
   obterBuff() {

--- a/src/tipo.enum.ts
+++ b/src/tipo.enum.ts
@@ -2,5 +2,6 @@ export enum enumTipo {
   ataque,
   cura,
   buff,
-  escudo
+  escudo,
+  veneno
 }


### PR DESCRIPTION
## Summary
- introduce `enumTipo.veneno`
- add poison card implementation and tests
- extend player with poison handling and methods
- trigger poison damage each turn in `Game`
- test poison stacking and application

## Testing
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684892a87c508328a45d437277f1ce76