### PR TITLE
Apply shield to poison damage

### DIFF
--- a/src/player.test.ts
+++ b/src/player.test.ts
@@ -421,6 +421,18 @@ describe("player", () => {
     expect(op.vida).toBe(25);
   });
 
+  it("Deve usar escudo para absorver dano acumulado de veneno", () => {
+    const op = new Player("op");
+    op.aplicarVeneno(2);
+    op.aplicarVeneno(1);
+    op.escudos = [3];
+    op.processarVenenos();
+    expect(op.vida).toBe(30);
+    expect(op.escudos.length).toBe(0);
+    op.processarVenenos();
+    expect(op.vida).toBe(29);
+  });
+
 
 
 

--- a/src/player.ts
+++ b/src/player.ts
@@ -90,7 +90,8 @@ export class Player {
     if (this.venenos.length === 0) {
       return;
     }
-    this.vida -= this.venenos.length;
+    const dano = this.venenos.length;
+    this.defenderAtaque(dano);
     this.venenos = this.venenos
       .map((v) => v - 1)
       .filter((v) => v > 0);


### PR DESCRIPTION
## Summary
- handle poison damage via `defenderAtaque`
- test shield interaction with venom damage

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6848947e58808328a0cf00d80f2a4346