### PR TITLE
Increase starting mana and card costs

### DIFF
--- a/src/game.test.ts
+++ b/src/game.test.ts
@@ -124,7 +124,7 @@ describe("Game", () => {
 
   it("Deve dar a possibilidade passar a vez se o jogador escolher -1 como entrada do ataque", () => {
     _sut.jogador1.manaSlot = 5;
-    _sut.jogador1.mao = [new CardAtaque(3), new CardAtaque(3), new CardAtaque(0), new CardAtaque(0)];
+    _sut.jogador1.mao = [new CardAtaque(3), new CardAtaque(3), new CardAtaque(1), new CardAtaque(1)];
     selecionarCarta.mockClear();
     selecionarCarta.mockReturnValueOnce(undefined);
     j1Atacar.mockImplementation((x) => {

--- a/src/player.test.ts
+++ b/src/player.test.ts
@@ -21,8 +21,8 @@ describe("player", () => {
     expect(_sut.vida).toBe(30);
   });
 
-  it("Deve ter 0 de mana no comeco do jogo", () => {
-    expect(_sut.mana).toBe(0);
+  it("Deve ter 1 de mana no comeco do jogo", () => {
+    expect(_sut.mana).toBe(1);
   });
 
   it("Deve ter 0 de espacos de mana no comeco do jogo", () => {
@@ -31,26 +31,26 @@ describe("player", () => {
 
   it("Deve iniciar o jogo com a seguinte combinacao de cartas", () => {
     expect(_sut.deck).toEqual([
-      new CardAtaque(0),
-      new CardAtaque(0),
       new CardAtaque(1),
       new CardAtaque(1),
       new CardAtaque(2),
       new CardAtaque(2),
-      new CardAtaque(2),
-      new CardAtaque(3),
       new CardAtaque(3),
       new CardAtaque(3),
       new CardAtaque(3),
       new CardAtaque(4),
       new CardAtaque(4),
       new CardAtaque(4),
+      new CardAtaque(4),
+      new CardAtaque(5),
       new CardAtaque(5),
       new CardAtaque(5),
       new CardAtaque(6),
       new CardAtaque(6),
       new CardAtaque(7),
+      new CardAtaque(7),
       new CardAtaque(8),
+      new CardAtaque(9),
     ]);
   });
 

--- a/src/player.ts
+++ b/src/player.ts
@@ -15,10 +15,10 @@ export class Player {
   constructor(nome: string) {
     this.nome = nome;
     this.vida = 30;
-    this.mana = 0;
+    this.mana = 1;
     this.manaSlot = 0;
     const valores = [
-      0, 0, 1, 1, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 5, 5, 6, 6, 7, 8,
+      1, 1, 2, 2, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 6, 6, 7, 7, 8, 9,
     ];
     this.deck = valores.map((v) => new CardAtaque(v));
     this.mao = [];


### PR DESCRIPTION
## Summary
- raise player's starting mana to 1
- increase all default card values by 1
- update tests to reflect new mana and deck values

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68489757de1c832895c21d79f705ea0b