### PR TITLE
Implement Mago class with enhanced buffs

### DIFF
--- a/src/mago.test.ts
+++ b/src/mago.test.ts
@@ -1,0 +1,29 @@
+import { Mago } from "./mago";
+import { CardBuff } from "./cards/cardBuff";
+import { CardAtaque } from "./cards/cardAtaque";
+
+describe("Mago", () => {
+  let mago: Mago;
+
+  beforeEach(() => {
+    mago = new Mago("Gandalf");
+  });
+
+  it("Deve aplicar buff de 30% por custo da carta", () => {
+    mago.mao = [new CardBuff(2)];
+    mago.mana = 2;
+
+    mago.buffar(new CardBuff(2));
+    expect(mago.obterBuff()).toBeCloseTo(1.6);
+  });
+
+  it("Deve aplicar buff de 30% no ataque", () => {
+    mago.mao = [new CardBuff(2), new CardAtaque(4)];
+    mago.mana = 6;
+
+    mago.buffar(new CardBuff(2));
+    const dano = mago.atacar(new CardAtaque(4));
+    expect(dano).toBe(6); // 4 * 1.6 = 6.4 -> round 6
+    expect(mago.obterBuff()).toBe(1);
+  });
+});

--- a/src/mago.ts
+++ b/src/mago.ts
@@ -1,0 +1,16 @@
+import { enumTipo } from "./tipo.enum";
+import { ICard } from "./cards/ICard";
+import { Player } from "./player";
+
+export class Mago extends Player {
+  constructor(nome: string) {
+    super(nome);
+  }
+
+  override buffar(carta: ICard) {
+    this.validarUtilizacao(carta, enumTipo.buff);
+    const cartaUsada = this.consumirCarta(carta);
+    const incremento = 1 + 0.3 * cartaUsada.obterCusto();
+    this.buff = this.buff * incremento;
+  }
+}

--- a/src/player.ts
+++ b/src/player.ts
@@ -27,12 +27,12 @@ export class Player {
     this.venenos = [];
   }
 
-  private consumirCarta(carta: ICard): ICard {
+  protected consumirCarta(carta: ICard): ICard {
     this.mana -= carta.obterCusto();
     const indice = this.mao.findIndex((c) => c.toEquals(carta));
     return this.mao.splice(indice, 1)[0];
   }
-  private validarUtilizacao(carta: ICard, tipo: enumTipo) {
+  protected validarUtilizacao(carta: ICard, tipo: enumTipo) {
     if (!this.mao.some((x) => x.toEquals(carta))) {
       throw new Error("Você não possui essa carta!");
     }


### PR DESCRIPTION
## Summary
- allow subclasses to use `consumirCarta` and `validarUtilizacao`
- create `Mago` player class with stronger buff ability
- add tests for the new class

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68489c58ae9c8328b3d64f857db1b092