### PR TITLE
Add mana card type

### DIFF
--- a/src/cards/cardMana.test.ts
+++ b/src/cards/cardMana.test.ts
@@ -1,0 +1,22 @@
+import { enumTipo } from "../tipo.enum";
+import { CardMana } from "./cardMana";
+
+describe("CardMana", () => {
+  let _sut: CardMana;
+
+  beforeEach(() => {
+    _sut = new CardMana(3);
+  });
+
+  it("Deve retornar o custo da carta quando a funcao obterCusto for chamada", () => {
+    expect(_sut.obterCusto()).toBe(3);
+  });
+
+  it("Deve retornar o valor da carta quando a funcao obterValor for chamada", () => {
+    expect(_sut.obterValor()).toBe(3);
+  });
+
+  it("Deve retornar o tipo mana quando a funcao obterTipo for chamada", () => {
+    expect(_sut.obterTipo()).toBe(enumTipo.mana);
+  });
+});

--- a/src/cards/cardMana.ts
+++ b/src/cards/cardMana.ts
@@ -1,0 +1,25 @@
+import { enumTipo } from "../tipo.enum";
+import { AbstractCard } from "./abstractCard";
+
+export class CardMana extends AbstractCard {
+  private custo: number;
+  private valor: number;
+
+  constructor(valor: number) {
+    super();
+    this.custo = valor;
+    this.valor = valor;
+  }
+
+  obterCusto(): number {
+    return this.custo;
+  }
+
+  obterValor(): number {
+    return this.valor;
+  }
+
+  obterTipo(): enumTipo {
+    return enumTipo.mana;
+  }
+}

--- a/src/game.test.ts
+++ b/src/game.test.ts
@@ -4,6 +4,7 @@ import { Game } from "./game";
 import { IInterfaceUsuario } from "./IInterfaceUsuario";
 import { CardCura } from "./cards/cardCura";
 import { CardBuff } from "./cards/cardBuff";
+import { CardMana } from "./cards/cardMana";
 import { ICard } from "./cards/ICard";
 
 describe("Game", () => {
@@ -235,6 +236,19 @@ describe("Game", () => {
     expect(atacarSpy).toBeCalledTimes(0);
     expect(curarSpy).toBeCalledTimes(0);
     expect(buffarSpy).toBeCalledTimes(1);
+  });
+
+  it("Deve chamar funcao carregarMana do jogador caso ele tenha escolhido uma carta do tipo mana", () => {
+    _sut.jogador1.mao = [new CardMana(2)];
+    _sut.jogador1.manaSlot = 2;
+    _sut.jogador1.reiniciarMana();
+    selecionarCarta.mockReturnValueOnce(new CardMana(2)).mockReturnValueOnce(undefined);
+
+    const carregarManaSpy = jest.spyOn(_sut.jogador1, "carregarMana");
+
+    _sut.rodarTurno(_sut.jogador1, _sut.jogador2);
+
+    expect(carregarManaSpy).toBeCalledTimes(1);
   });
 });
 

--- a/src/game.ts
+++ b/src/game.ts
@@ -38,6 +38,7 @@ export class Game {
   rodarTurno(jogadorAtacante: Player, jogadorDefensor: Player) {
     jogadorAtacante.incrementarManaSlot();
     jogadorAtacante.reiniciarMana();
+    jogadorAtacante.aplicarManaExtra();
     jogadorAtacante.comprarCarta();
 
     if (!jogadorAtacante.estaVivo()) {
@@ -65,6 +66,9 @@ export class Game {
       }
       if (carta.obterTipo() === enumTipo.escudo) {
         jogadorAtacante.proteger(carta);
+      }
+      if (carta.obterTipo() === enumTipo.mana) {
+        jogadorAtacante.carregarMana(carta);
       }
 
     }

--- a/src/player.test.ts
+++ b/src/player.test.ts
@@ -3,6 +3,7 @@ import { CardAtaque } from "./cards/cardAtaque";
 import { CardCura } from "./cards/cardCura";
 import { CardBuff } from "./cards/cardBuff";
 import { CardEscudo } from "./cards/cardEscudo";
+import { CardMana } from "./cards/cardMana";
 import { enumTipo } from "./tipo.enum";
 
 describe("player", () => {
@@ -387,6 +388,31 @@ describe("player", () => {
     _sut.proteger(new CardEscudo(2));
     expect(_sut.mao.length).toBe(1);
     expect(_sut.mana).toBe(1);
+  });
+
+  it("Deve acumular mana extra para o proximo turno", () => {
+    _sut.mao = [new CardMana(2)];
+    _sut.mana = 2;
+    _sut.carregarMana(new CardMana(2));
+    expect(_sut.manaExtra).toBe(2);
+    expect(_sut.buff).toBe(1);
+  });
+
+  it("Deve aplicar mana extra no inicio do turno", () => {
+    _sut.manaExtra = 3;
+    _sut.mana = 5;
+    _sut.aplicarManaExtra();
+    expect(_sut.mana).toBe(8);
+    expect(_sut.manaExtra).toBe(0);
+  });
+
+  it("Deve aplicar buff na carta de mana", () => {
+    _sut.mao = [new CardBuff(2), new CardMana(2)];
+    _sut.mana = 4;
+    _sut.buffar(new CardBuff(2));
+    _sut.carregarMana(new CardMana(2));
+    expect(_sut.manaExtra).toBeCloseTo(2.4);
+    expect(_sut.buff).toBe(1);
   });
 
 

--- a/src/player.ts
+++ b/src/player.ts
@@ -10,6 +10,7 @@ export class Player {
   mao: ICard[];
   buff: number;
   escudos: number[];
+  manaExtra: number;
 
   constructor(nome: string) {
     this.nome = nome;
@@ -23,6 +24,7 @@ export class Player {
     this.mao = [];
     this.buff = 1;
     this.escudos = [];
+    this.manaExtra = 0;
   }
 
   private consumirCarta(carta: ICard): ICard {
@@ -70,6 +72,13 @@ export class Player {
     this.buff = 1;
   }
 
+  carregarMana(carta: ICard) {
+    this.validarUtilizacao(carta, enumTipo.mana);
+    const cartaUsada = this.consumirCarta(carta);
+    this.manaExtra += cartaUsada.obterValor() * this.buff;
+    this.buff = 1;
+  }
+
   obterBuff() {
     return this.buff;
   }
@@ -106,6 +115,11 @@ export class Player {
       this.mao.length > 0 &&
       this.mao.some((carta) => carta.obterCusto() <= this.mana)
     );
+  }
+
+  aplicarManaExtra() {
+    this.mana += Math.round(this.manaExtra);
+    this.manaExtra = 0;
   }
 
   defenderAtaque(dano: number) {

--- a/src/tipo.enum.ts
+++ b/src/tipo.enum.ts
@@ -2,5 +2,6 @@ export enum enumTipo {
   ataque,
   cura,
   buff,
-  escudo
+  escudo,
+  mana
 }


### PR DESCRIPTION
## Summary
- add `enumTipo.mana` to represent mana cards
- create `CardMana` for granting mana next turn
- allow players to use mana cards and apply accumulated buffs
- enable `Game` to handle mana cards each turn
- test mana card behavior, player methods, and game flow

## Testing
- `npx jest --runInBand`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68488fdb98888328b6a753612729beec