### PR TITLE
Add poison bonus for Thief

### DIFF
--- a/src/player.test.ts
+++ b/src/player.test.ts
@@ -6,6 +6,7 @@ import { CardEscudo } from "./cards/cardEscudo";
 import { CardMana } from "./cards/cardMana";
 import { CardVeneno } from "./cards/cardVeneno";
 import { enumTipo } from "./tipo.enum";
+import { enumClasse } from "./classe.enum";
 
 describe("player", () => {
   let _sut: Player;
@@ -458,6 +459,33 @@ describe("player", () => {
     op.processarVenenos();
     expect(op.vida).toBe(29);
 
+  });
+
+  it("Jogadores da classe Ladrao aumentam em 2 turnos a duracao do veneno", () => {
+    _sut.mao = [new CardVeneno(2)];
+    _sut.mana = 2;
+    _sut.classe = enumClasse.ladrao;
+
+    const duracao = _sut.envenenar(new CardVeneno(2));
+    expect(duracao).toBe(4);
+    const oponente = new Player("op");
+    oponente.aplicarVeneno(duracao);
+    for (let i = 0; i < 4; i++) {
+      oponente.processarVenenos();
+    }
+    expect(oponente.vida).toBe(26);
+    oponente.processarVenenos();
+    expect(oponente.vida).toBe(26);
+  });
+
+  it("Bonus de veneno do ladrao considera o buff aplicado", () => {
+    _sut.mao = [new CardBuff(2), new CardVeneno(2)];
+    _sut.mana = 4;
+    _sut.classe = enumClasse.ladrao;
+
+    _sut.buffar(new CardBuff(2));
+    const duracao = _sut.envenenar(new CardVeneno(2));
+    expect(duracao).toBe(4);
   });
 
 

--- a/src/player.ts
+++ b/src/player.ts
@@ -97,7 +97,10 @@ export class Player {
   envenenar(carta: ICard) {
     this.validarUtilizacao(carta, enumTipo.veneno);
     const cartaUsada = this.consumirCarta(carta);
-    const duracao = Math.floor(cartaUsada.obterValor() * this.buff);
+    let duracao = Math.floor(cartaUsada.obterValor() * this.buff);
+    if (this.classe === enumClasse.ladrao) {
+      duracao += 2;
+    }
     this.buff = 1;
     return duracao;
   }


### PR DESCRIPTION
## Summary
- extend poison duration by 2 turns for the `ladrao` class
- test Thief poison bonus and buff interaction

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6848c06a6aa483288b9d2be85574eee0