### PR TITLE
Add turn display to console

### DIFF
--- a/src/ConsoleInterface.ts
+++ b/src/ConsoleInterface.ts
@@ -1,10 +1,14 @@
 import { IInterfaceUsuario } from "./IInterfaceUsuario";
 import { ICard } from "./cards/ICard";
+import { Player } from "./player";
 import promptSync from "prompt-sync";
 
 const prompt = promptSync();
 
 export class ConsoleInterface implements IInterfaceUsuario {
+  exibirTurno(jogador: Player): void {
+    console.log(`----- Turno de ${jogador.nome} -----`);
+  }
   selecionarCarta(mao: ICard[], mana: number): ICard | undefined {
     const opcoes = mao
       .map((c, i) => `${i}:${c.obterValor()}(c${c.obterCusto()})`)

--- a/src/IInterfaceUsuario.ts
+++ b/src/IInterfaceUsuario.ts
@@ -1,5 +1,7 @@
 import { ICard } from "./cards/ICard";
+import { Player } from "./player";
 
 export interface IInterfaceUsuario {
   selecionarCarta(mao: ICard[], mana: number): ICard | undefined;
+  exibirTurno(jogador: Player): void;
 }

--- a/src/game.test.ts
+++ b/src/game.test.ts
@@ -34,7 +34,8 @@ describe("Game", () => {
     selecionarCarta = jest.fn().mockReturnValue(new CardAtaque(3));
     interfaceUsuario = {
       selecionarCarta,
-    };
+      exibirTurno: jest.fn(),
+    } as unknown as IInterfaceUsuario;
 
     j1Atacar = jest.spyOn(p1, "atacar").mockImplementation((x) => {
       _sut.jogador1.mana -= x.obterCusto();

--- a/src/game.ts
+++ b/src/game.ts
@@ -45,6 +45,8 @@ export class Game {
       jogadorAtacante.mana += 1;
     }
 
+    this.iu.exibirTurno(jogadorAtacante);
+
     jogadorAtacante.comprarCarta();
 
     if (!jogadorAtacante.estaVivo()) {


### PR DESCRIPTION
## Summary
- update user interface to show the current player's turn
- expose `exibirTurno` in interface and implementation
- notify turn start inside the game logic
- adjust tests for new interface method

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6848cf417dc8832894e9a4c89e81143b