### PR TITLE
Improve console UI for card actions

### DIFF
--- a/src/ConsoleInterface.ts
+++ b/src/ConsoleInterface.ts
@@ -9,6 +9,16 @@ export class ConsoleInterface implements IInterfaceUsuario {
   exibirTurno(jogador: Player): void {
     console.log(`----- Turno de ${jogador.nome} -----`);
   }
+  exibirCartaEscolhida(carta: ICard): void {
+    console.log(
+      `Carta escolhida: Valor ${carta.obterValor()} (custo ${carta.obterCusto()})`
+    );
+  }
+  exibirDano(alvo: Player, dano: number): void {
+    console.log(
+      `${alvo.nome} sofreu ${dano} de dano e possui ${alvo.vida} de vida`
+    );
+  }
   selecionarCarta(mao: ICard[], mana: number): ICard | undefined {
     const opcoes = mao
       .map((c, i) => `${i}:${c.obterValor()}(c${c.obterCusto()})`)

--- a/src/IInterfaceUsuario.ts
+++ b/src/IInterfaceUsuario.ts
@@ -4,4 +4,6 @@ import { Player } from "./player";
 export interface IInterfaceUsuario {
   selecionarCarta(mao: ICard[], mana: number): ICard | undefined;
   exibirTurno(jogador: Player): void;
+  exibirCartaEscolhida?(carta: ICard): void;
+  exibirDano?(alvo: Player, dano: number): void;
 }

--- a/src/game.ts
+++ b/src/game.ts
@@ -68,11 +68,17 @@ export class Game {
       if (!carta) {
         break;
       }
+      if (this.iu.exibirCartaEscolhida) {
+        this.iu.exibirCartaEscolhida(carta);
+      }
 
       switch (carta.obterTipo()) {
         case enumTipo.ataque: {
           const dano = jogadorAtacante.atacar(carta);
           jogadorDefensor.defenderAtaque(dano);
+          if (this.iu.exibirDano) {
+            this.iu.exibirDano(jogadorDefensor, dano);
+          }
           if (!jogadorDefensor.estaVivo()) {
             this.Vencedor = jogadorAtacante;
           }


### PR DESCRIPTION
## Summary
- expand user interface with optional methods to display chosen cards and damage
- implement those methods for the console interface
- show selected card and damage feedback during turns

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6848d31c48008328a48c60466d8aa689