### PR TITLE
Add CPU player option

### DIFF
--- a/src/CpuInterface.ts
+++ b/src/CpuInterface.ts
@@ -1,0 +1,13 @@
+import { ConsoleInterface } from "./ConsoleInterface";
+import { ICard } from "./cards/ICard";
+
+export class CpuInterface extends ConsoleInterface {
+  selecionarCarta(mao: ICard[], mana: number): ICard | undefined {
+    const jogaveis = mao.filter((c) => c.obterCusto() <= mana);
+    if (jogaveis.length === 0) {
+      return undefined;
+    }
+    const indice = Math.floor(Math.random() * jogaveis.length);
+    return jogaveis[indice];
+  }
+}

--- a/src/game.test.ts
+++ b/src/game.test.ts
@@ -47,7 +47,7 @@ describe("Game", () => {
       _sut.jogador1.mao.splice(_sut.jogador1.mao.findIndex(y => y.toEquals(x)), 1);
     });
 
-    _sut = new Game(p1, p2, interfaceUsuario);
+    _sut = new Game(p1, p2, interfaceUsuario, interfaceUsuario);
   });
 
   afterEach(() => {

--- a/src/game.ts
+++ b/src/game.ts
@@ -7,11 +7,22 @@ export class Game {
   jogador1: Player;
   jogador2: Player;
   Vencedor: Player | undefined;
-  iu: IInterfaceUsuario;
-  constructor(jogador1: Player, jogador2: Player, iu: IInterfaceUsuario) {
+  iuJogador1: IInterfaceUsuario;
+  iuJogador2: IInterfaceUsuario;
+  constructor(
+    jogador1: Player,
+    jogador2: Player,
+    iuJogador1: IInterfaceUsuario,
+    iuJogador2: IInterfaceUsuario
+  ) {
     this.jogador1 = jogador1;
     this.jogador2 = jogador2;
-    this.iu = iu;
+    this.iuJogador1 = iuJogador1;
+    this.iuJogador2 = iuJogador2;
+  }
+
+  private interfaceDoJogador(jogador: Player): IInterfaceUsuario {
+    return jogador === this.jogador1 ? this.iuJogador1 : this.iuJogador2;
   }
 
   iniciarJogo() {
@@ -51,7 +62,8 @@ export class Game {
       jogadorAtacante.mana += 1;
     }
 
-    this.iu.exibirTurno(jogadorAtacante);
+    const iuAtual = this.interfaceDoJogador(jogadorAtacante);
+    iuAtual.exibirTurno(jogadorAtacante);
 
     jogadorAtacante.comprarCarta();
 
@@ -61,23 +73,23 @@ export class Game {
     }
 
     while (jogadorAtacante.temCartaDisponivel()) {
-      const carta: ICard | undefined = this.iu.selecionarCarta(
+      const carta: ICard | undefined = iuAtual.selecionarCarta(
         jogadorAtacante.mao,
         jogadorAtacante.mana
       );
       if (!carta) {
         break;
       }
-      if (this.iu.exibirCartaEscolhida) {
-        this.iu.exibirCartaEscolhida(carta);
+      if (iuAtual.exibirCartaEscolhida) {
+        iuAtual.exibirCartaEscolhida(carta);
       }
 
       switch (carta.obterTipo()) {
         case enumTipo.ataque: {
           const dano = jogadorAtacante.atacar(carta);
           jogadorDefensor.defenderAtaque(dano);
-          if (this.iu.exibirDano) {
-            this.iu.exibirDano(jogadorDefensor, dano);
+          if (iuAtual.exibirDano) {
+            iuAtual.exibirDano(jogadorDefensor, dano);
           }
           if (!jogadorDefensor.estaVivo()) {
             this.Vencedor = jogadorAtacante;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,18 +1,30 @@
 import { Game } from "./game";
 import { Player } from "./player";
 import { ConsoleInterface } from "./ConsoleInterface";
+import { CpuInterface } from "./CpuInterface";
+import { IInterfaceUsuario } from "./IInterfaceUsuario";
 import promptSync from "prompt-sync";
 
 const prompt = promptSync();
 
+const modo = prompt("Quantidade de jogadores (1 ou 2): ");
 const nome1 = prompt("Nome Jogador 1: ");
-const nome2 = prompt("Nome Jogador 2: ");
+let nome2: string;
+
+let iu1: IInterfaceUsuario = new ConsoleInterface();
+let iu2: IInterfaceUsuario;
+if (modo.trim() === "1") {
+  nome2 = "CPU";
+  iu2 = new CpuInterface();
+} else {
+  nome2 = prompt("Nome Jogador 2: ");
+  iu2 = new ConsoleInterface();
+}
 
 const jogador1 = new Player(nome1);
 const jogador2 = new Player(nome2);
 
-const iu = new ConsoleInterface();
-const game = new Game(jogador1, jogador2, iu);
+const game = new Game(jogador1, jogador2, iu1, iu2);
 
 game.iniciarJogo();
 


### PR DESCRIPTION
## Summary
- update Game to accept two user interfaces
- add automated CPU interface for single-player mode
- allow choosing number of players in CLI
- adjust tests for new Game constructor

## Testing
- `npm test` *(fails: player initial deck expectation mismatch)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6848d5f34a108328b1d2993c3616db93