### PR TITLE
Implement card effect notifications

### DIFF
--- a/specs.txt
+++ b/specs.txt
@@ -36,6 +36,8 @@ Criar sistema de profissoes de jogador (mage, thief, barbaro, bardo, guerreiro)
 - A mana e reiniciada de acordo com os slots disponiveis.
 - Jogar cartas enquanto houver mana suficiente.
 - Efeitos de buff, escudo e veneno sao processados conforme as cartas.
+- Informar vida e escudos no inicio do turno e o dano recebido por veneno.
+- Exibir o efeito de cada carta utilizada, como cura aplicada e porcentagem de buff.
 
 4. Tipos de carta
 - Ataque: causa dano direto.

--- a/src/ConsoleInterface.ts
+++ b/src/ConsoleInterface.ts
@@ -20,6 +20,43 @@ export class ConsoleInterface implements IInterfaceUsuario {
       `${alvo.nome} sofreu ${dano} de dano e possui ${alvo.vida} de vida`
     );
   }
+
+  exibirInicioTurno(
+    jogador: Player,
+    vidaInicial: number,
+    danoVeneno: number
+  ): void {
+    const escudos = jogador.escudos.join(", ") || "0";
+    console.log(`Vida: ${vidaInicial} - Escudos: ${escudos}`);
+    if (danoVeneno > 0) {
+      console.log(`Sofreu ${danoVeneno} de dano de veneno`);
+      console.log(`Vida atual: ${jogador.vida}`);
+    }
+  }
+
+  exibirCura(cura: number, vidaTotal: number): void {
+    console.log(`Cura de ${cura}. Vida atual: ${vidaTotal}`);
+  }
+
+  exibirBuffAplicado(percentual: number): void {
+    console.log(`Buff de ${percentual}% aplicado`);
+  }
+
+  exibirBuffNaCarta(percentual: number): void {
+    console.log(`Esta acao recebera bonus de ${percentual}%`);
+  }
+
+  exibirEscudo(valor: number): void {
+    console.log(`Escudo ativado com valor ${valor}`);
+  }
+
+  exibirManaExtra(valor: number): void {
+    console.log(`Mana extra de ${valor} para o proximo turno`);
+  }
+
+  exibirVeneno(duracao: number): void {
+    console.log(`Veneno aplicado por ${duracao} turno(s)`);
+  }
   selecionarCarta(mao: ICard[], mana: number): ICard | undefined {
     const opcoes = mao
       .map(

--- a/src/IInterfaceUsuario.ts
+++ b/src/IInterfaceUsuario.ts
@@ -6,4 +6,15 @@ export interface IInterfaceUsuario {
   exibirTurno(jogador: Player): void;
   exibirCartaEscolhida?(carta: ICard): void;
   exibirDano?(alvo: Player, dano: number): void;
+  exibirInicioTurno?(
+    jogador: Player,
+    vidaInicial: number,
+    danoVeneno: number
+  ): void;
+  exibirCura?(cura: number, vidaTotal: number): void;
+  exibirBuffAplicado?(percentual: number): void;
+  exibirBuffNaCarta?(percentual: number): void;
+  exibirEscudo?(valor: number): void;
+  exibirManaExtra?(valor: number): void;
+  exibirVeneno?(duracao: number): void;
 }

--- a/src/player.ts
+++ b/src/player.ts
@@ -125,13 +125,15 @@ export class Player {
 
   processarVenenos() {
     if (this.venenos.length === 0) {
-      return;
+      return 0;
     }
     const dano = this.venenos.length;
+    const vidaAntes = this.vida;
     this.defenderAtaque(dano);
     this.venenos = this.venenos
       .map((v) => v - 1)
       .filter((v) => v > 0);
+    return vidaAntes - this.vida;
   }
 
 


### PR DESCRIPTION
## Summary
- update game specs about displaying turn status and card effects
- expand `IInterfaceUsuario` with optional notification methods
- implement messaging in `ConsoleInterface`
- return damage value from `processarVenenos`
- show buffed actions and card effects during turns

## Testing
- `npm test` *(fails: player test expects 20 cards but 44 are created)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68497fb0bbc08328ae1f880407f2173e