### PR TITLE
Implement card list sorting and numbering

### DIFF
--- a/specs.txt
+++ b/specs.txt
@@ -3,7 +3,7 @@ Criar interface para o jogador (Console)
 Nome Jogador 1: 
 Nome jogador 2:
 
-"Com qual carta voce quer atacar [2,5,6] --- Mana 3/6":
+As cartas devem ser listadas em multiplas linhas, ordenadas por valor crescente e numeradas a partir de 1 durante a selecao de cartas do turno.
 
 "jogador vencedor: "
 

--- a/src/ConsoleInterface.ts
+++ b/src/ConsoleInterface.ts
@@ -58,20 +58,19 @@ export class ConsoleInterface implements IInterfaceUsuario {
     console.log(`Veneno aplicado por ${duracao} turno(s)`);
   }
   selecionarCarta(mao: ICard[], mana: number): ICard | undefined {
-    const opcoes = mao
-      .map(
-        (c, i) =>
-          `${i}:${obterNomeTipo(c.obterTipo())} ${c.obterValor()}(c${c.obterCusto()})`
-      )
-      .join(", ");
-    const resposta = prompt(
-      `Com qual carta voce quer jogar [${opcoes}] --- Mana ${mana}: `
-    );
+    const ordenadas = [...mao].sort((a, b) => a.obterValor() - b.obterValor());
+    console.log("Qual carta voce quer jogar?");
+    ordenadas.forEach((c, i) => {
+      console.log(
+        `${i + 1} - ${obterNomeTipo(c.obterTipo())} ${c.obterValor()}(c${c.obterCusto()})`
+      );
+    });
+    const resposta = prompt(`Opcao (0 para passar) --- Mana ${mana}: `);
     const indice = parseInt(resposta, 10);
-    if (isNaN(indice) || indice < 0 || indice >= mao.length) {
+    if (isNaN(indice) || indice <= 0 || indice > ordenadas.length) {
       return undefined;
     }
-    const carta = mao[indice];
+    const carta = ordenadas[indice - 1];
     if (carta.obterCusto() > mana) {
       console.log("Mana insuficiente!");
       return undefined;


### PR DESCRIPTION
## Summary
- improve `selecionarCarta` to list cards one-per-line
- sort options by value and index from 1
- document the new card selection behaviour

## Testing
- `npm test` *(fails: player test expects old deck size)*

------
https://chatgpt.com/codex/tasks/task_e_684983198fc483289643ac1faa23b8be