### PR TITLE
Implement initial menu and deck storage

### DIFF
--- a/specs.txt
+++ b/specs.txt
@@ -24,13 +24,14 @@ Criar sistema de profissoes de jogador (mage, thief, barbaro, bardo, guerreiro)
 
 ==== Especificacao Funcional ====
 1. Inicio
-- Perguntar a quantidade de jogadores (1 ou 2).
-- No modo solo o segundo jogador e controlado pela CPU.
-- Solicitar o nome de cada jogador.
-- Cada jogador monta um deck de 40 cartas antes de escolher a classe.
-- O deck e formado por 10 boosters de 8 cartas aleatorias cada um, dos quais o jogador escolhe 4.
-- A CPU realiza o mesmo processo automaticamente.
-- O booster deve ser exibido apos cada escolha para atualizar os indices restantes.
+- Exibir menu com as opcoes:
+  1 - Single player
+  2 - Multiplayer
+  3 - Criar deck
+  4 - Fechar
+- Decks criados sao gravados em arquivo.
+- Ao iniciar uma partida cada jogador pode escolher um deck salvo ou usar o deck padrao.
+- Apos o termino da partida o menu e exibido novamente.
 
 2. Objetivo
 - Cada jogador comeca com 30 pontos de vida.

--- a/src/deckStorage.ts
+++ b/src/deckStorage.ts
@@ -1,0 +1,59 @@
+import fs from "fs";
+import path from "path";
+import { ICard } from "./cards/ICard";
+import { enumTipo } from "./tipo.enum";
+import { CardAtaque } from "./cards/cardAtaque";
+import { CardCura } from "./cards/cardCura";
+import { CardBuff } from "./cards/cardBuff";
+import { CardEscudo } from "./cards/cardEscudo";
+import { CardMana } from "./cards/cardMana";
+import { CardVeneno } from "./cards/cardVeneno";
+
+const DECK_DIR = path.join(__dirname, "../decks");
+
+function ensureDir(): void {
+  if (!fs.existsSync(DECK_DIR)) {
+    fs.mkdirSync(DECK_DIR);
+  }
+}
+
+export function saveDeck(name: string, deck: ICard[]): void {
+  ensureDir();
+  const data = deck.map((c) => ({ tipo: c.obterTipo(), valor: c.obterValor() }));
+  fs.writeFileSync(path.join(DECK_DIR, `${name}.json`), JSON.stringify(data));
+}
+
+function createCard(tipo: enumTipo, valor: number): ICard {
+  switch (tipo) {
+    case enumTipo.ataque:
+      return new CardAtaque(valor);
+    case enumTipo.cura:
+      return new CardCura(valor);
+    case enumTipo.buff:
+      return new CardBuff(valor);
+    case enumTipo.escudo:
+      return new CardEscudo(valor);
+    case enumTipo.mana:
+      return new CardMana(valor);
+    default:
+      return new CardVeneno(valor);
+  }
+}
+
+export function loadDeck(name: string): ICard[] | undefined {
+  try {
+    const file = fs.readFileSync(path.join(DECK_DIR, `${name}.json`), "utf-8");
+    const data: { tipo: enumTipo; valor: number }[] = JSON.parse(file);
+    return data.map((d) => createCard(d.tipo, d.valor));
+  } catch {
+    return undefined;
+  }
+}
+
+export function listDecks(): string[] {
+  ensureDir();
+  return fs
+    .readdirSync(DECK_DIR)
+    .filter((f) => f.endsWith(".json"))
+    .map((f) => f.replace(/\.json$/, ""));
+}


### PR DESCRIPTION
## Summary
- add deck persistence helper
- redesign `main.ts` with initial menu to create decks and start games
- update functional specification with new menu flow

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849e39b5a5883288d1a8ce47e91e7bd